### PR TITLE
[new] /note/new

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -21,6 +21,11 @@ export default new Router({
         import(/* webpackChunkName: "about" */ "./views/About.vue")
     },
     {
+      path: "/note/new",
+      name: "new",
+      component: () => import("./views/New.vue")
+    },
+    {
       path: "/note/:id/edit",
       name: "edit",
       component: () => import("./views/Edit.vue")

--- a/src/views/New.vue
+++ b/src/views/New.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-container />
+</template>
+
+<script>
+export default {
+  beforeCreate: function() {
+    // 新規ノートを作成後、新規ノートのidを取得して/editへ飛ばす
+    const db = this.$db;
+    const Note = db.getSchema().table("Note");
+
+    const row = Note.createRow({
+      title: "",
+      content: "",
+      created_at: new Date(),
+      updated_at: new Date()
+    });
+
+    db.insert()
+      .into(Note)
+      .values([row])
+      .exec()
+      .then(res => {
+        const id = res[0].id;
+        this.$router.push({ name: "edit", params: { id } });
+      });
+  }
+};
+</script>


### PR DESCRIPTION
新規ノートを作成できるようになった。
`/note/new` へアクセス時、新規ノートを作成してから対応するidのeditへ飛ばす。