### PR TITLE
不要なスクロールバーを削除

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,3 +22,9 @@ export default {
   name: "App"
 };
 </script>
+
+<style lang="sass">
+// これを書いておかないと常にスクロールバーが出てしまう(Vuetify起因？）
+html
+  overflow-y: visible !important
+</style>


### PR DESCRIPTION
詳細は未調査のため不明だが、このスタイルを書いておかないと常に画面右端にスクロールバーが表示される。
Vuetify起因な気がしてる。