### PR TITLE
[add] github-markdwon.css

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7227,6 +7227,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "github-markdown-css": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-3.0.1.tgz",
+      "integrity": "sha512-9G5CIPsHoyk5ObDsb/H4KTi23J8KE1oDd4KYU51qwqeM+lKWAiO7abpSgCkyWswgmSKBiuE7/4f8xUz7f2qAiQ=="
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "bootswatch": "^4.3.1",
     "chai-as-promised": "^7.1.1",
     "core-js": "^2.6.5",
+    "github-markdown-css": "^3.0.1",
     "highlightjs": "^9.12.0",
     "lovefield": "^2.1.12",
     "marked": "^0.7.0",

--- a/src/components/MarkdownPreview.vue
+++ b/src/components/MarkdownPreview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="preview">
     <h1 id="title">{{ title }}</h1>
-    <p v-html="render(content)" />
+    <p v-html="render(content)" class="markdown-body" />
   </div>
 </template>
 
@@ -9,6 +9,7 @@
 import marked from "marked";
 import hljs from "highlightjs";
 import "highlight.js/styles/github.css";
+import "github-markdown-css/github-markdown.css";
 
 marked.setOptions({
   langPrefix: "",


### PR DESCRIPTION
Close #35 

* github-markdwon.cssを導入し、markdownレンダリング時の体裁を整えた